### PR TITLE
Simplify Julia example.

### DIFF
--- a/calculate_fasta_median_length.jl
+++ b/calculate_fasta_median_length.jl
@@ -1,37 +1,17 @@
-#! /Applications/Julia-0.4.5.app/Contents/Resources/julia/bin/julia
-# Geoffrey Hannigan
-# Pat Schloss Lab
-# University of Michigan
+#!/usr/bin/env julia
 
-# Read in fasta file
-fastain = open(ARGS[1], "r") # Read in the file
+function fasta_median()
+    fasta_in = open(ARGS[1], "r")
+    length_array = Float64[]
 
-LengthArray = []
+    for line::ASCIIString in eachline(fasta_in)
+        if !ismatch(r"^\>", line)
+            push!(length_array, length(chomp(line)))
+        end
+    end
 
-# println("Creaeting length array...")
-for line in eachline(fastain)
-	if !ismatch(r"^\>", line)
-		newline = chomp(line)
-		LineLength = length(newline)
-		# println(LineLength)
-		push!(LengthArray, LineLength)
-	end
+    close(fasta_in)
+    return median(length_array)
 end
 
-# println("Sorting array...")
-SortedArray = sort(LengthArray)
-# println(SortedArray)
-ArrayLength = length(SortedArray)
-
-# println("Calculating median length...")
-if ArrayLength % 2 == 0
-	result = SortedArray[div(ArrayLength,2)]
-	println(result)
-else
-	one = SortedArray[div(ArrayLength,2)-1]
-	two = SortedArray[div(ArrayLength,2)-1]
-	result = div((one + two),2)
-	println(result)
-end
-
-close(fastain)
+println(fasta_median())


### PR DESCRIPTION
It should be noticed that Julia uses a  JIT (just in time) compiler, and that you are not only measuring how long the code takes to run, but also Julia initialization time, you should at least wrap your code in a `let` or `function` block, instead of running everything at the global scope, see:
- http://stackoverflow.com/questions/34615746/why-does-my-julia-code-run-so-slowly

Notice how the first time Julia has to JIT the function (for each combination of argument types) but subsequent times it uses the cached native_code and takes less time and memory:

``` julia
julia> add(x, y) = x + y
add (generic function with 1 method)

julia> @time 1 + 1
  0.000013 seconds (149 allocations: 10.714 KB)
2

julia> @time 1 + 1
  0.000005 seconds (4 allocations: 160 bytes)
2
```

I tried also this:
- https://gitter.im/BioJulia/Bio.jl?at=5770cb79a0c12d110f9308b9

It's not only shorter but a little faster:

``` julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.5 (2016-03-18 00:58 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-w64-mingw32

julia> cd("Documents\\JuliaPerlBenchmark-master")

julia> push!(ARGS, "uniprot-bacteriophage-2.fasta")
1-element Array{UTF8String,1}:
 "uniprot-bacteriophage-2.fasta"

julia> function fasta_median()
           fasta_in = open(ARGS[1], "r")
           length_array = Float64[]

           for line::ASCIIString in eachline(fasta_in)
               if !ismatch(r"^\>", line)
                   push!(length_array, length(chomp(line)))
               end
           end

           close(fasta_in)
           return median(length_array)
       end
fasta_median (generic function with 1 method)

julia> @time main()    # JIT happens here!
  2.157544 seconds (2.80 M allocations: 144.808 MB, 4.44% gc time)
60.0

julia> @time main()
  0.834137 seconds (2.66 M allocations: 138.162 MB, 2.40% gc time)
60.0

julia> @code_warntype fasta_median()
Variables:
  fasta_in::IOStream
  length_array::Array{Float64,1}
  #s1::Void
  line::ASCIIString
  _var0::Bool
  _var1::Bool

Body:
  begin  # none, line 2:
      fasta_in = (Main.open)((Base.arrayref)(Main.ARGS,1)::UTF8String,"r")::IOStream # none, line 3:
      length_array = (Main.getindex)(Main.Float64)::Array{Float64,1} # none, line 5:
      GenSym(2) = AST(:($(Expr(:lambda, Any[], Any[Any[],Any[],0,Any[]], :(begin  # io.jl, line 273:
        return Base.nothing
    end::Any)))))
      GenSym(0) = $(Expr(:new, :((top(getfield))(Base,:EachLine)::Type{EachLine}), :(fasta_in::IOStream), GenSym(2)))
      #s1 = Base.nothing
      unless !((Base.eof)((top(getfield))(GenSym(0),:stream)::IO)::Any)::Any goto 9
      _var0 = false
      goto 10
      9:
      ((top(getfield))(GenSym(0),:ondone)::F)()::Any
      _var0 = true
      10:
      unless (Base.box)(Base.Bool,(Base.not_int)(_var0::Bool)) goto 1
      2:
      GenSym(3) = (top(getfield))(GenSym(0),:stream)::IO
      GenSym(9) = (Base.readuntil)(GenSym(3),'\n')::Any
      GenSym(10) = Base.nothing
      line = (top(typeassert))((top(convert))(Main.ASCIIString,GenSym(9))::Any,Main.ASCIIString)::ASCIIString
      #s1 = GenSym(10) # none, line 6:
      GenSym(4) = r"^\>"
      (Base.compile)(GenSym(4))::Regex
      GenSym(5) = (Base.PCRE.exec)((top(getfield))(GenSym(4),:regex)::Ptr{Void},line::ASCIIString,0,(top(getfield))(GenSym(4),:match_options)::UInt32,(top(getfield))(GenSym(4),:match_data)::Ptr{Void})::Bool
      unless (Base.box)(Base.Bool,(Base.not_int)(GenSym(5))) goto 4 # none, line 7:
      GenSym(6) = (Main.chomp)(line::ASCIIString)::ASCIIString
      (Main.push!)(length_array::Array{Float64,1},(Base.arraylen)((top(getfield))(GenSym(6),:data)::Array{UInt8,1})::Int64)::Array{Float64,1}
      4:
      3:
      unless !((Base.eof)((top(getfield))(GenSym(0),:stream)::IO)::Any)::Any goto 16
      _var1 = false
      goto 17
      16:
      ((top(getfield))(GenSym(0),:ondone)::F)()::Any
      _var1 = true
      17:
      unless (Base.box)(Base.Bool,(Base.not_int)((Base.box)(Base.Bool,(Base.not_int)(_var1::Bool)))) goto 2
      1:
      0:  # none, line 11:
      GenSym(7) = (top(getfield))(fasta_in::IOStream,:ios)::Array{UInt8,1}
      (top(ccall))(:ios_close,Base.Void,(top(svec))((top(apply_type))(Base.Ptr,Base.Void)::Type{Ptr{Void}})::SimpleVector,(top(ccall))(:jl_array_ptr,(top(apply_type))(Base.Ptr,Base.Void)::Type{Ptr{Void}},(top(svec))(Base.Any)::SimpleVector,GenSym(7),0)::Ptr{Void},GenSym(7))::Void # none, line 12:
      GenSym(8) = (Base.copy)(length_array::Array{Float64,1})::Array{Float64,1}
      return (Base.median!)(GenSym(8))::Float64
  end::Float64

julia>
```

It still allocates way to much memory IMO.
